### PR TITLE
Allow windows users to run commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const { S3 } = require('aws-sdk')
 
 const run = (cmd, args, options) => new Promise((resolve, reject) => {
   console.error(`${chalk.grey('running:')} ${chalk.yellow(cmd)} ${chalk.yellow(args.join(' '))} ${chalk.grey('...')}`)
-  const p = spawn(cmd, args, options)
+  const p = spawn(cmd, args, { ...options, shell: true })
   let stdout = []
   let stderr = []
 


### PR DESCRIPTION
When setting up the Elivagar stack using windows I ran into an error when packaging lambdas.
 
![image](https://user-images.githubusercontent.com/16656834/65268059-2d9d2380-dacb-11e9-8cff-d0001d5a5c2a.png)

Pulling down the repo and investigator further revealed that spawn doesn't execute npm commands in windows: https://github.com/nodejs/node/issues/3675. 


https://github.com/nodejs/node/issues/3675#issuecomment-308963807
Node docs: https://nodejs.org/api/child_process.html#child_process_default_windows_shell

Please test.