### PR TITLE
fix: iris-1661/1700 Put and Delete Device Image

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,8 +15,9 @@ program
     'Do not install it as an npm package. A package.json is required but only for the name and version.')
   .option('--script-install <packages>', 'Run "npm install --only=prod" on the comma-delimited list of ' +
     'packages, which runs scripts in their package.json. All scripts in all other packages are ignored.', commaSeparatedList)
-  .action(async (bucket, { source, layer, scriptInstall }) => {
-    process.stdout.write(await local(bucket, source, layer, scriptInstall))
+  .option('--always-upload', 'Always upload files even if they already exist on S3.')
+  .action(async (bucket, { source, layer, scriptInstall, alwaysUpload }) => {
+    process.stdout.write(await local(bucket, source, layer, scriptInstall, alwaysUpload))
   })
 
 program.parse(process.argv)

--- a/cli.js
+++ b/cli.js
@@ -1,13 +1,22 @@
 #!/usr/bin/env node
+'use strict'
+
 const program = require('commander')
 const { local } = require('./index')
+
+function commaSeparatedList(value, dummyPrevious) {
+  return value.split(',');
+}
 
 program
   .command('local <bucket>')
   .option('-s, --source <directory>', 'Source location', process.env.PWD)
-  .option('-l, --layer', 'Source tree is a Lambda layer. Package the tree as-is. Do not install it as an npm package. A package.json is required but only for the name and version.')
-  .action(async (bucket, { source, layer }) => {
-    process.stdout.write(await local(bucket, source, layer))
+  .option('-l, --layer', 'Source tree is a Lambda layer. Package the tree as-is. ' +
+    'Do not install it as an npm package. A package.json is required but only for the name and version.')
+  .option('--script-install <packages>', 'Run "npm install --only=prod" on the comma-delimited list of ' +
+    'packages, which runs scripts in their package.json. All scripts in all other packages are ignored.', commaSeparatedList)
+  .action(async (bucket, { source, layer, scriptInstall }) => {
+    process.stdout.write(await local(bucket, source, layer, scriptInstall))
   })
 
 program.parse(process.argv)

--- a/index.js
+++ b/index.js
@@ -52,8 +52,6 @@ const publishToS3 = async (zipFileName, tempDir, bucket) => {
   return s3.putObject({ Body: zipData, Bucket: bucket, Key: zipFileName }).promise()
 }
 
-// No longer used! Upload to S3 always, because the file being uploaded could have
-// the same name but different contents (Lambda coda), especially in development
 const existsOnS3 = async (zipFileName, bucket) => {
   const s3 = new S3()
   return s3
@@ -65,12 +63,16 @@ const existsOnS3 = async (zipFileName, bucket) => {
     .catch(() => false)
 }
 
-const local = async (bucket, sourcefolder, layer, scriptInstallPackages) => createTempDir()
+const local = async (bucket, sourcefolder, layer, scriptInstallPackages, alwaysUpload) => createTempDir()
   .then(async tempDir => {
     const pkg = path.join(sourcefolder, 'package.json')
     const { name, version } = JSON.parse(await readFile(pkg), 'utf-8')
     console.error(`${chalk.blue(name)} ${chalk.green(version)}`)
     const zipFileName = `${name.split('/')[1] || name}-${version}.zip`
+    if (!alwaysUpload && await existsOnS3(zipFileName, bucket)) {
+      console.error(chalk.yellow(`s3://${bucket}/${zipFileName} exists`))
+      return zipFileName
+    }
     try {
       if (layer) {
         // For a Lambda layer, zip up the entire source tree. Don't install it.

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ const local = async (bucket, sourcefolder, layer, scriptInstallPackages, alwaysU
       if (scriptInstallPackages) {
         for (let i = 0; i < scriptInstallPackages.length; i++) {
           console.error(`${chalk.gray('Installing with scripts:')} ${chalk.yellow(scriptInstallPackages[i])}`)
-          await run('npm', ['install', '--only=prod', scriptInstallPackages[i]], { cwd: tempDir })
+          await run('npm', ['ci', '--only=prod', scriptInstallPackages[i]], { cwd: tempDir })
         }
       }
       console.error(`${chalk.gray('Uploading to S3:')} ${chalk.yellow(bucket)}${chalk.gray('/')}${chalk.yellow(zipFileName)}`)

--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ const publishToS3 = async (zipFileName, tempDir, bucket) => {
   return s3.putObject({ Body: zipData, Bucket: bucket, Key: zipFileName }).promise()
 }
 
+// No longer used! Upload to S3 always, because the file being uploaded could have
+// the same name but different contents (Lambda coda), especially in development
 const existsOnS3 = async (zipFileName, bucket) => {
   const s3 = new S3()
   return s3
@@ -69,10 +71,6 @@ const local = async (bucket, sourcefolder, layer, scriptInstallPackages) => crea
     const { name, version } = JSON.parse(await readFile(pkg), 'utf-8')
     console.error(`${chalk.blue(name)} ${chalk.green(version)}`)
     const zipFileName = `${name.split('/')[1] || name}-${version}.zip`
-    if (await existsOnS3(zipFileName, bucket)) {
-      console.error(chalk.yellow(`s3://${bucket}/${zipFileName} exists`))
-      return zipFileName
-    }
     try {
       if (layer) {
         // For a Lambda layer, zip up the entire source tree. Don't install it.

--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ const run = (cmd, args, options) => new Promise((resolve, reject) => {
   let stderr = []
 
   p.stdout.on('data', data => {
-    process.stdout.write(chalk.magenta(data.toString()))
+    // Re-route stdout to stderr, because the only thing the 'local' function should return to stdout
+    // is the name of the zip file.
+    process.stderr.write(chalk.magenta(data.toString()))
     stdout.push(data.toString())
   })
 
@@ -74,9 +76,11 @@ const local = async (bucket, sourcefolder, layer, scriptInstallPackages) => crea
     try {
       if (layer) {
         // For a Lambda layer, zip up the entire source tree. Don't install it.
+        console.error(`${chalk.gray('Packaging as Lambda layer')}`)
         await ncp(sourcefolder, tempDir)
       } else {
         // For a Lambda function, zip up the file structure we expect
+        console.error(`${chalk.gray('Packaging as Lambda function')}`)
         await ncp(pkg, path.join(tempDir, 'package.json'))
         await ncp(path.join(sourcefolder, 'package-lock.json'), path.join(tempDir, 'package-lock.json'))
         await ncp(path.join(sourcefolder, 'dist'), path.join(tempDir, 'dist'))

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ const local = async (bucket, sourcefolder, layer, scriptInstallPackages, alwaysU
       if (scriptInstallPackages) {
         for (let i = 0; i < scriptInstallPackages.length; i++) {
           console.error(`${chalk.gray('Installing with scripts:')} ${chalk.yellow(scriptInstallPackages[i])}`)
-          await run('npm', ['ci', '--only=prod', scriptInstallPackages[i]], { cwd: tempDir })
+          await run('npm', ['install', '--only=prod', scriptInstallPackages[i]], { cwd: tempDir })
         }
       }
       console.error(`${chalk.gray('Uploading to S3:')} ${chalk.yellow(bucket)}${chalk.gray('/')}${chalk.yellow(zipFileName)}`)


### PR DESCRIPTION
Allows running scripts for a given package, needed for device image Lambda (installing "sharp" library)
Allows forcing .zip files to upload to S3 even if it already exists, for cases where the contents might not be the same as the file in S3 (not used yet)